### PR TITLE
Query report

### DIFF
--- a/BugReport/GitHubBugReport.csproj
+++ b/BugReport/GitHubBugReport.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Reports\AlertsReport\IssueEntry.cs" />
     <Compile Include="Reports\AlertsReport\ConfigLoader.cs" />
     <Compile Include="Reports\AlertsReport\AlertReporting.cs" />
+    <Compile Include="Reports\HtmlReport\QueryReport.cs" />
     <Compile Include="Reports\HtmlReport\HtmlReport.cs" />
     <Compile Include="Reports\AlertsReport\GitHubQuery.cs" />
     <Compile Include="Repository.cs" />

--- a/BugReport/Program.cs
+++ b/BugReport/Program.cs
@@ -15,6 +15,7 @@ class Program
         Console.WriteLine("  cache <config.xml> [<GithubToken>]- will cache all GitHub issues into file Issues_YYY-MM-DD@HH-MM.json");
         Console.WriteLine("  cacheWithComments <alerts.xml> [<GithubToken>] - will cache all GitHub issues into file Issues_YYY-MM-DD@HH-MM.json and Github comments into file Comments_YYY-MM-DD@HH-MM.json");
         Console.WriteLine("  report <input.json> <output.html> <config.xml> - Creates report of GitHub issues from cached .json file");
+        Console.WriteLine("  query <input.json> <output.html> <config.xml> - Creates (hardcoded) query-report of GitHub issues from cached .json file");
         Console.WriteLine("  alerts <input1.json> <input2.json> <emailTemplate.html> <config.xml> [<alert_name>] - Sends alert emails based on .xml config, optinally filtered to just alert_name");
         Console.WriteLine("      alerts_SkipEmail or set SEND_EMAIL=0 - Won't send any emails");
         Console.WriteLine("  untriaged <issues.json> <emailTemplate.html> <config.xml> [<alert_name>] - Sends alert emails based on .xml config, optinally filtered to just alert_name");
@@ -51,6 +52,11 @@ class Program
                 else if (args[0].Equals("report", StringComparison.OrdinalIgnoreCase) && (args.Length == 4))
                 {
                     HtmlReport(args[1], args[2], args[3]);
+                    return (int)ErrorCode.Success;
+                }
+                else if (args[0].Equals("query", StringComparison.OrdinalIgnoreCase) && (args.Length == 4))
+                {
+                    QueryReport(args[1], args[2], args[3]);
                     return (int)ErrorCode.Success;
                 }
                 else if ((args[0].Equals("alerts", StringComparison.OrdinalIgnoreCase)
@@ -112,6 +118,12 @@ class Program
     static void HtmlReport(string inputJsonFileName, string outputHtmlFileName, string configFileName)
     {
         HtmlReport report = new HtmlReport(configFileName);
+        report.Write(IssueCollection.LoadFrom(inputJsonFileName), outputHtmlFileName);
+    }
+
+    static void QueryReport(string inputJsonFileName, string outputHtmlFileName, string configFileName)
+    {
+        QueryReport report = new QueryReport(configFileName);
         report.Write(IssueCollection.LoadFrom(inputJsonFileName), outputHtmlFileName);
     }
 

--- a/BugReport/Query/Parser.cs
+++ b/BugReport/Query/Parser.cs
@@ -137,7 +137,7 @@ namespace BugReport.Query
             if (token.IsOperatorNot())
             {
                 parser.Skip();
-                Expression expr = new ExpressionNot(Parse());
+                Expression expr = new ExpressionNot(ParseExpression_Single());
                 if (expr == null)
                 {
                     throw new InvalidQueryException("The sub-expression after NOT operator is empty", queryString, token.Position);
@@ -180,7 +180,7 @@ namespace BugReport.Query
                     }
                     else
                     {
-                        throw new InvalidQueryException("Unexpected value in key-value pair, expected: [pr|issue|open|close]", queryString, token.Position);
+                        throw new InvalidQueryException($"Unexpected value '{token}' in key-value pair, expected: [pr|issue|open|close]", queryString, token.Position);
                     }
                 }
                 else if (token.IsKeyValuePair("assignee"))
@@ -199,12 +199,12 @@ namespace BugReport.Query
                     }
                     else
                     {
-                        throw new InvalidQueryException("Unexpected value in key-value pair, expected: [milestone|assignee]", queryString, token.Position);
+                        throw new InvalidQueryException($"Unexpected value '{token}' in key-value pair, expected: [milestone|assignee]", queryString, token.Position);
                     }
                 }
                 else
                 {
-                    throw new InvalidQueryException("Unexpected key in key-value pair, expected: [label|-label|milestone|is|assignee]", queryString, token.Position);
+                    throw new InvalidQueryException($"Unexpected key '{token}' in key-value pair, expected: [label|-label|milestone|is|assignee]", queryString, token.Position);
                 }
                 parser.Skip();
                 return expr;

--- a/BugReport/Query/Parser.cs
+++ b/BugReport/Query/Parser.cs
@@ -28,6 +28,12 @@ namespace BugReport.Query
             parser = new QuerySyntaxParser(queryString);
         }
 
+        public static Expression Parse(string queryString)
+        {
+            QueryParser queryParser = new QueryParser(queryString);
+            return queryParser.Parse();
+        }
+
         public Expression Parse()
         {
             Expression expr = ParseExpression_Or();

--- a/BugReport/Query/Token.cs
+++ b/BugReport/Query/Token.cs
@@ -118,10 +118,10 @@ namespace BugReport.Query
         public override string ToString()
         {
             if ((Word1 == null) && (Word2 == null))
-                return String.Format("{0}", TokenType);
+                return $"{TokenType}";
             if (Word2 == null)
-                return String.Format("{0} {1}", TokenType, Word1);
-            return String.Format("{0} {1}:{2}", TokenType, Word1, Word2);
+                return $"{Word1}";
+            return $"{Word1}:{Word2}";
         }
     }
 }

--- a/BugReport/Reports/AlertsReport/Alert.cs
+++ b/BugReport/Reports/AlertsReport/Alert.cs
@@ -14,11 +14,11 @@ namespace BugReport.Reports
         public string Name { get; private set; }
         public Expression Query { get; private set; }
 
-        public NamedQuery(string name, string query)
+        public NamedQuery(string name, string query, IReadOnlyDictionary<string, Expression> customIsValues)
         {
             Name = name;
 
-            Query = QueryParser.Parse(query);
+            Query = QueryParser.Parse(query, customIsValues);
         }
         public NamedQuery(string name, Expression query)
         {
@@ -48,8 +48,13 @@ namespace BugReport.Reports
         public IEnumerable<User> Owners { get; private set; }
         public IEnumerable<User> CCs { get; private set; }
 
-        public Alert(string name, string query, IEnumerable<User> owners, IEnumerable<User> ccList) : 
-            base(name, query)
+        public Alert(
+            string name, 
+            string query, 
+            IReadOnlyDictionary<string, Expression> customIsValues, 
+            IEnumerable<User> owners, 
+            IEnumerable<User> ccList) 
+            : base(name, query, customIsValues)
         {
             Owners = owners;
             CCs = ccList;

--- a/BugReport/Reports/AlertsReport/Alert.cs
+++ b/BugReport/Reports/AlertsReport/Alert.cs
@@ -18,8 +18,7 @@ namespace BugReport.Reports
         {
             Name = name;
 
-            QueryParser queryParser = new QueryParser(query);
-            Query = queryParser.Parse();
+            Query = QueryParser.Parse(query);
         }
         public NamedQuery(string name, Expression query)
         {

--- a/BugReport/Reports/AlertsReport/AlertReport_Diff.cs
+++ b/BugReport/Reports/AlertsReport/AlertReport_Diff.cs
@@ -12,7 +12,8 @@ namespace BugReport.Reports
 {
     public class AlertReport_Diff : AlertReport
     {
-        public AlertReport_Diff(Alert alert, bool sendEmail, string htmlTemplateFileName) : base(alert, sendEmail, htmlTemplateFileName)
+        public AlertReport_Diff(Alert alert, bool sendEmail, string htmlTemplateFileName) 
+            : base(alert, sendEmail, htmlTemplateFileName)
         {
         }
 

--- a/BugReport/Reports/AlertsReport/AlertReport_NeedsMSResponse.cs
+++ b/BugReport/Reports/AlertsReport/AlertReport_NeedsMSResponse.cs
@@ -14,7 +14,8 @@ namespace BugReport.Reports
     {
         private TimeSpan _acceptableResponseDelay = new TimeSpan(5, 0, 0, 0, 0); // 5 days
 
-        public AlertReport_NeedsMSResponse(Alert alert, bool sendEmail, string htmlTemplateFileName) : base(alert, sendEmail, htmlTemplateFileName)
+        public AlertReport_NeedsMSResponse(Alert alert, bool sendEmail, string htmlTemplateFileName) 
+            : base(alert, sendEmail, htmlTemplateFileName)
         {
         }
 

--- a/BugReport/Reports/AlertsReport/AlertReporting.cs
+++ b/BugReport/Reports/AlertsReport/AlertReporting.cs
@@ -22,14 +22,12 @@ namespace BugReport.Reports
     {
         private bool _skipEmail;
         private AlertType _type;
-        private IEnumerable<Alert> _alerts;
-        private IEnumerable<Label> _labels;
+        Config _config;
         private string _htmlTemplateFileName;
 
         public AlertReporting(string configFileName, bool skipEmail, string htmlTemplateFileName, AlertType type)
         {
-            ConfigLoader loader = new ConfigLoader();
-            loader.Load(configFileName, out _alerts, out _labels);
+            _config = new Config(configFileName);
 
             _type = type;
             _skipEmail = skipEmail;
@@ -54,7 +52,7 @@ namespace BugReport.Reports
                 smtpClient = new SmtpClient("smtphost");
                 smtpClient.UseDefaultCredentials = true;
             }
-            foreach (Alert alert in _alerts)
+            foreach (Alert alert in _config.Alerts)
             {
                 Console.WriteLine("Alert: {0}", alert.Name);
                 if ((filteredAlertName != null) && (filteredAlertName != alert.Name))
@@ -82,7 +80,7 @@ namespace BugReport.Reports
             if (_type == AlertType.Diff)
                 report = new AlertReport_Diff(alert, !_skipEmail, _htmlTemplateFileName);
             else if (_type == AlertType.Untriaged)
-                report = new AlertReport_Untriaged(alert, !_skipEmail, _htmlTemplateFileName, _labels);
+                report = new AlertReport_Untriaged(alert, !_skipEmail, _htmlTemplateFileName, _config.UntriagedExpression);
             else if (_type == AlertType.NeedsMSResponse)
                 report = new AlertReport_NeedsMSResponse(alert, !_skipEmail, _htmlTemplateFileName);
             else

--- a/BugReport/Reports/AlertsReport/IssueEntry.cs
+++ b/BugReport/Reports/AlertsReport/IssueEntry.cs
@@ -28,7 +28,7 @@ namespace BugReport.Reports
                 idPrefix = "PR ";
             }
 
-            IssueId = string.Format("{0}#<a href=\"{1}\">{2}</a>", idPrefix, issue.HtmlUrl, issue.Number);
+            IssueId = $"{idPrefix}#<a href=\"{issue.HtmlUrl}\">{issue.Number}</a>";
 
             Title = issue.Title;
 
@@ -40,7 +40,7 @@ namespace BugReport.Reports
             }
             else if (issue.Assignee != null)
             {
-                AssignedToText = string.Format("<a href=\"{0}\">@{1}</a>", issue.Assignee.HtmlUrl, issue.Assignee.Login);
+                AssignedToText = $"<a href=\"{issue.Assignee.HtmlUrl}\">@{issue.Assignee.Login}</a>";
             }
             else
             {

--- a/BugReport/Reports/HtmlReport/QueryReport.cs
+++ b/BugReport/Reports/HtmlReport/QueryReport.cs
@@ -19,12 +19,13 @@ namespace BugReport.Reports
 
         public void Write(IssueCollection issuesCollection, string outputHtmlFile)
         {
-            string queryString = @"is:issue AND is:open AND milestone:2.0.0 AND " +
-                //"-label:os-windows AND (label:os-linux OR label:mac-os-x) AND 
-                @"-label:os-linux AND -label:mac-os-x AND 
-                -label:test-run-core AND 
-                label:area-System.Net.Security";
-                //"(label:area-System.Net OR label:area-System.Net.Sockets OR label:area-System.Net.Security OR label:area-System.Net.Http)";
+            string queryString = @"is:issue AND is:open AND milestone:2.0.0 AND" +
+                //" -label:os-windows AND (label:os-linux OR label:mac-os-x) AND" +
+                //@" -label:os-linux AND -label:mac-os-x AND" +
+                //@" -label:test-run-core AND" +
+                @" !(label:test-run-core OR label:test-run-desktop OR label:disabled-test) AND" +
+                @" label:area-System.IO";
+                //" (label:area-System.Net OR label:area-System.Net.Sockets OR label:area-System.Net.Security OR label:area-System.Net.Http)";
             Expression query = QueryParser.Parse(queryString);
 
             IEnumerable<DataModelIssue> issues = query.Evaluate(issuesCollection.Issues);

--- a/BugReport/Reports/HtmlReport/QueryReport.cs
+++ b/BugReport/Reports/HtmlReport/QueryReport.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BugReport.DataModel;
+using BugReport.Query;
+
+namespace BugReport.Reports
+{
+    public class QueryReport
+    {
+        public QueryReport(string configFileName)
+        {
+            ConfigLoader loader = new ConfigLoader();
+            loader.Load(configFileName, out _, out _);
+        }
+
+        public void Write(IssueCollection issuesCollection, string outputHtmlFile)
+        {
+            string queryString = @"is:issue AND is:open AND milestone:2.0.0 AND " +
+                //"-label:os-windows AND (label:os-linux OR label:mac-os-x) AND 
+                @"-label:os-linux AND -label:mac-os-x AND 
+                -label:test-run-core AND 
+                label:area-System.Net.Security";
+                //"(label:area-System.Net OR label:area-System.Net.Sockets OR label:area-System.Net.Security OR label:area-System.Net.Http)";
+            Expression query = QueryParser.Parse(queryString);
+
+            IEnumerable<DataModelIssue> issues = query.Evaluate(issuesCollection.Issues);
+            using (StreamWriter file = new StreamWriter(outputHtmlFile))
+            {
+                file.WriteLine(
+@"<html>
+<head>
+    <style>
+        table
+        {
+            /* border-collapse: collapse; */
+            border: 1px solid black;
+        }
+        table td
+        {
+            border: 1px solid black;
+        }
+        table th
+        {
+            border: 1px solid black;
+        }
+        div.labels
+        {
+            color: #808080;
+            font-style: italic;
+            margin-left: 1cm;
+        }
+    </style>
+</head>
+<body>");
+                file.WriteLine("<h2>Query</h2>");
+                file.WriteLine($"<p>{queryString}</p>");
+                file.WriteLine($"Count: {issues.Count()}<br/>");
+                file.WriteLine(FormatIssueTable(issues.Select(issue => new IssueEntry(issue))));
+                file.WriteLine("</body></html>");
+            }
+        }
+
+        private string FormatIssueTable(IEnumerable<IssueEntry> issues)
+        {
+            StringBuilder text = new StringBuilder();
+            text.AppendLine("<table border=\"1\">");
+            text.AppendLine("  <tr>");
+            text.AppendLine("    <th>Issue #</th>");
+            text.AppendLine("    <th>Title</th>");
+            text.AppendLine("    <th>Assigned To</th>");
+            text.AppendLine("    <th>Milestone</th>");
+            text.AppendLine("  </tr>");
+            foreach (IssueEntry issue in issues)
+            {
+                text.AppendLine("  <tr>");
+                text.AppendLine($"    <td>{issue.IssueId}</td>");
+                text.AppendLine("    <td>");
+                text.AppendLine($"      {issue.Title}");
+                if (issue.LabelsText != null)
+                {
+                    text.AppendLine($"      <br/><div class=\"labels\">Labels: {issue.LabelsText}</div>");
+                }
+                text.AppendLine("    </td>");
+                text.AppendLine($"    <td>{issue.AssignedToText}</td>");
+                text.AppendLine($"    <td>{issue.MilestoneText}</td>");
+                text.AppendLine("  </tr>");
+            }
+            text.AppendLine("</table>");
+
+            return text.ToString();
+        }
+    }
+}


### PR DESCRIPTION
* Introduces 'query' report - list of queries from config file

* Customizes 'report' report queries - also from config file
```html
    <queries>
        <query name="myQuery">label:MyLabel</query>
    </queries>
```

* Enhances 'report' report with table sorted by issue count

* Introduces "is:untriaged" query syntax
  * Configured by area labels, issue type labels and untriaged labels from config file
  * QueryParser customizable for any is:* values


Fixes #14, #15, #34, #36, #37, #39