### PR TITLE
Fix infinite recursion in IEnumerable<T>.None()

### DIFF
--- a/BugReport/Util/Extensions.cs
+++ b/BugReport/Util/Extensions.cs
@@ -17,7 +17,7 @@ namespace BugReport.Util
 
         public static bool None<T>(this IEnumerable<T> items)
         {
-            return items.None();
+            return !items.Any();
         }
     }
 }


### PR DESCRIPTION
Note: Previous refactoring of `!IEnumerable<T>.Any()` pattern was too eager