### PR TITLE
'query' report fixes

### DIFF
--- a/BugReport/DataModel/IssueCollection.cs
+++ b/BugReport/DataModel/IssueCollection.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
+using BugReport.Util;
 
 namespace BugReport.DataModel
 {
@@ -87,7 +85,7 @@ namespace BugReport.DataModel
             IDictionary<string, Label> labelAliases, 
             IssueKindFlags issueKind = IssueKindFlags.All)
         {
-            return LoadIssues(new string[] { fileName }, labelAliases, issueKind);
+            return LoadIssues(fileName.ToEnumerable(), labelAliases, issueKind);
         }
 
         public static IEnumerable<DataModelIssue> LoadIssues(

--- a/BugReport/GitHubBugReport.csproj
+++ b/BugReport/GitHubBugReport.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Query\ExpressionMultiRepo.cs" />
+    <Compile Include="Reports\HtmlReport\Report.cs" />
     <Compile Include="Repository.cs" />
     <Compile Include="DataModel\IssueCollection.cs" />
     <Compile Include="DataModel\DataModelIssue.cs" />

--- a/BugReport/Query/ExpressionMultiRepo.cs
+++ b/BugReport/Query/ExpressionMultiRepo.cs
@@ -27,7 +27,7 @@ namespace BugReport.Query
         public IEnumerable<RepoExpression> RepoExpressions
         {
             get => _expressions.Select(entry => new RepoExpression(entry.Key, entry.Value))
-                    .Concat(new RepoExpression[] { new RepoExpression(null, _defaultExpression) });
+                    .Concat(new RepoExpression(null, _defaultExpression).ToEnumerable());
         }
 
         private ExpressionMultiRepo(Dictionary<Repository, Expression> expressions, Expression defaultExpression)

--- a/BugReport/Reports/Alert.cs
+++ b/BugReport/Reports/Alert.cs
@@ -40,15 +40,6 @@ namespace BugReport.Reports
             }
         }
 
-        public NamedQuery(
-            string name,
-            string queryName,
-            IReadOnlyDictionary<string, Expression> customIsValues)
-        {
-            Name = name;
-            Query = QueryParser.Parse(queryName, customIsValues);
-        }
-
         public NamedQuery(string name, Expression query)
         {
             Name = name;

--- a/BugReport/Reports/Config.cs
+++ b/BugReport/Reports/Config.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Mail;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using BugReport.Query;
 using BugReport.DataModel;
+using BugReport.Util;
 
 namespace BugReport.Reports
 {
@@ -192,11 +189,15 @@ namespace BugReport.Reports
                         string queryName = queryNode.Attribute("name").Value;
 
                         string queryString = queryNode.Value.ToString();
+                        string repo = queryNode.Attribute("repo")?.Value;
 
                         NamedQuery query;
                         try
                         {
-                            query = new NamedQuery(queryName, queryString, customIsValues);
+                            query = new NamedQuery(
+                                queryName, 
+                                new NamedQuery.RepoQuery(repo, queryString).ToEnumerable(), 
+                                customIsValues);
                         }
                         catch (InvalidQueryException ex)
                         {

--- a/BugReport/Reports/HtmlReport/QueryReport.cs
+++ b/BugReport/Reports/HtmlReport/QueryReport.cs
@@ -9,7 +9,7 @@ using BugReport.Query;
 
 namespace BugReport.Reports
 {
-    public class QueryReport
+    public class QueryReport : Report
     {
         Config _config;
 
@@ -54,8 +54,8 @@ namespace BugReport.Reports
                     IEnumerable<DataModelIssue> queryIssues = query.Query.Evaluate(issues);
 
                     file.WriteLine($"<h2>Query: {query.Name}</h2>");
-                    file.WriteLine($"<p>{query.Query}</p>");
-                    file.WriteLine($"Count: {queryIssues.Count()}<br/>");
+                    file.WriteLine($"<p>Query: <code>{query.Query}</code></p>");
+                    file.WriteLine($"Count: {GetQueryCountLinked_Multiple(query.Query, queryIssues, shouldHyperLink: true, useRepositoriesFromIssues: true)}<br/>");
                     file.WriteLine(FormatIssueTable(queryIssues.Select(issue => new IssueEntry(issue))));
                 }
 

--- a/BugReport/Reports/HtmlReport/Report.cs
+++ b/BugReport/Reports/HtmlReport/Report.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using BugReport.Util;
+using BugReport.DataModel;
+using BugReport.Query;
+
+namespace BugReport.Reports
+{
+    public class Report
+    {
+        protected static string GetQueryCountLinked(
+            Expression query, 
+            IEnumerable<DataModelIssue> issues, 
+            bool shouldHyperLink = true, 
+            bool useRepositoriesFromIssues = true)
+        {
+            int count = issues.Count();
+            if (!shouldHyperLink)
+            {
+                return count.ToString();
+            }
+            string gitHubQueryURL = query.GetGitHubQueryURL();
+            if (gitHubQueryURL != null)
+            {
+                IEnumerable<Repository> repos = useRepositoriesFromIssues ? Repository.GetReposOrDefault(issues) : Repository.Repositories;
+                if (repos.Count() <= 1)
+                {
+                    Repository repo = repos.First();
+                    return $"<a href=\"{repo.GetQueryUrl(gitHubQueryURL)}\">{count}</a>";
+                }
+                else
+                {
+                    return $"{count} <small>(" +
+                        string.Join(" + ", repos.Select(
+                            repo => $"<a href=\"{repo.GetQueryUrl(gitHubQueryURL)}\">{issues.Where(repo).Count()}</a>")) +
+                        ")</small>";
+                }
+            }
+            return count.ToString();
+        }
+
+        protected static string GetQueryCountLinked_Multiple(
+            Expression query, 
+            IEnumerable<DataModelIssue> issues, 
+            bool shouldHyperLink = true, 
+            bool useRepositoriesFromIssues = true)
+        {
+            Expression normalizedQuery = query.Normalized;
+            string gitHubQueryURL = normalizedQuery.GetGitHubQueryURL();
+            if (gitHubQueryURL != null)
+            {
+                return GetQueryCountLinked(normalizedQuery, issues, shouldHyperLink, useRepositoriesFromIssues);
+            }
+
+            int count = issues.Count();
+            if (!shouldHyperLink)
+            {
+                return count.ToString();
+            }
+
+            // Pattern from code:QueryReport for repo-scoped queries
+            if (normalizedQuery is ExpressionMultiRepo)
+            {
+                return GetQueryCountLinked_Multiple(
+                    (ExpressionMultiRepo)normalizedQuery,
+                    (Expression expr) => expr,
+                    issues,
+                    count,
+                    useRepositoriesFromIssues);
+            }
+
+            // Recognize pattern used by code:HtmlReport - columnQuery AND rowQuery
+            if (query is ExpressionAnd)
+            {
+                Expression[] andExpressions = ((ExpressionAnd)query).Expressions.ToArray();
+                if (andExpressions.Length == 2)
+                {
+                    Expression colQuery = andExpressions[1];
+                    if (colQuery.GetGitHubQueryURL() != null)
+                    {
+                        Expression rowQuery = andExpressions[0].Normalized;
+                        if (rowQuery is ExpressionOr)
+                        {
+                            // Wrap the query by MultiRepo expression
+                            ExpressionMultiRepo multiRepoRowQuery = new ExpressionMultiRepo(
+                                new RepoExpression(null, rowQuery).ToEnumerable());
+                            Debug.Assert(multiRepoRowQuery.IsNormalized());
+
+                            return GetQueryCountLinked_Multiple(
+                                multiRepoRowQuery,
+                                (Expression expr) => Expression.And(expr, colQuery),
+                                issues,
+                                count,
+                                useRepositoriesFromIssues);
+                        }
+                        else if (rowQuery is ExpressionMultiRepo)
+                        {
+                            return GetQueryCountLinked_Multiple(
+                                (ExpressionMultiRepo)rowQuery,
+                                (Expression expr) => Expression.And(expr, colQuery),
+                                issues,
+                                count,
+                                useRepositoriesFromIssues);
+                        }
+                    }
+                }
+            }
+            return count.ToString();
+        }
+
+        private static string GetQueryCountLinked_Multiple(
+            ExpressionMultiRepo multiRepoQuery,
+            Func<Expression, Expression> queryTransform,
+            IEnumerable<DataModelIssue> issues,
+            int issuesCount,
+            bool useRepositoriesFromIssues = true)
+        {
+            IEnumerable<RepoExpression> repoExpressions =
+                (useRepositoriesFromIssues ? Repository.GetReposOrDefault(issues) : Repository.Repositories)
+                    .SelectMany(
+                        repo =>
+                        {
+                            Expression expr = multiRepoQuery.GetExpression(repo);
+                            if (expr is ExpressionOr)
+                            {
+                                return ((ExpressionOr)expr).Expressions.Select(e => new RepoExpression(repo, e));
+                            }
+                            return new RepoExpression(repo, expr).ToEnumerable();
+                        });
+
+            if ((repoExpressions.Count() <= 6) &&
+                repoExpressions.Where(re => (re.Expr.GetGitHubQueryURL() == null)).None())
+            {
+                return
+                    $"{issuesCount} <small>(" +
+                    string.Join("+", repoExpressions.Select(
+                        re =>
+                        {
+                            Expression subQuery = queryTransform(re.Expr);
+                            int subCount = subQuery.Evaluate(issues.Where(re.Repo)).Count();
+                            string subQueryURL = subQuery.GetGitHubQueryURL();
+                            Debug.Assert(subQueryURL != null);
+                            return $"<a href=\"{re.Repo.GetQueryUrl(subQueryURL)}\">{subCount}</a>";
+                        })) +
+                    ")</small>";
+            }
+            return issuesCount.ToString();
+        }
+    }
+}

--- a/BugReport/Util/Extensions.cs
+++ b/BugReport/Util/Extensions.cs
@@ -19,5 +19,10 @@ namespace BugReport.Util
         {
             return !items.Any();
         }
+
+        public static IEnumerable<T> ToEnumerable<T>(this T value)
+        {
+            yield return value;
+        }
     }
 }


### PR DESCRIPTION
* Queries can be scoped per repo - fixes #75
* Link query count to the GitHub query - fixes #74
    * Refactor logic from HtmlReport into Report parent
* Refactoring: Add T.ToEnumerable() extension method and use it