### PR TITLE
Bug fix: Encode issue title as HTML

### DIFF
--- a/BugReport/Reports/EmailReport/AlertReport_Diff.cs
+++ b/BugReport/Reports/EmailReport/AlertReport_Diff.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
+using System.Web;
 using BugReport.DataModel;
 using BugReport.Util;
-using BugReport.Query;
 
 namespace BugReport.Reports.EmailReports
 {
@@ -116,7 +113,7 @@ namespace BugReport.Reports.EmailReports
                 text.AppendLine("  <tr>");
                 text.AppendLine($"    <td>{issue.IssueId}</td>");
                 text.AppendLine("    <td>");
-                text.AppendLine($"      {issue.Title}");
+                text.AppendLine($"      {HttpUtility.HtmlEncode(issue.Title)}");
                 if (issue.LabelsText != null)
                 {
                     text.AppendLine($"      <br/><div class=\"labels\">Labels: {issue.LabelsText}</div>");

--- a/BugReport/Reports/EmailReport/AlertReport_NeedsMSResponse.cs
+++ b/BugReport/Reports/EmailReport/AlertReport_NeedsMSResponse.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Web;
 using BugReport.DataModel;
 using BugReport.Util;
 
@@ -124,7 +125,7 @@ namespace BugReport.Reports.EmailReports
                 text.AppendLine($"    <td>{entry.IssueId}</td>");
                 text.AppendLine($"    <td>{pair.Value.Value.Days}</td>");
                 text.AppendLine("    <td>");
-                text.AppendLine($"      {entry.Title}");
+                text.AppendLine($"      {HttpUtility.HtmlEncode(entry.Title)}");
                 if (entry.LabelsText != null)
                 {
                     text.AppendLine($"      <br/><div class=\"labels\">Labels: {entry.LabelsText}</div>");

--- a/BugReport/Reports/EmailReport/AlertReport_Untriaged.cs
+++ b/BugReport/Reports/EmailReport/AlertReport_Untriaged.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Web;
 using BugReport.DataModel;
 using BugReport.Util;
 
@@ -89,7 +90,7 @@ namespace BugReport.Reports.EmailReports
                 text.AppendLine($"    <td>{issue.IssueId}</td>");
                 text.AppendLine($"    <td>{UntriagedTypeToString(mapEntry.Value)}</td>");
                 text.AppendLine("    <td>");
-                text.AppendLine($"      {issue.Title}");
+                text.AppendLine($"      {HttpUtility.HtmlEncode(issue.Title)}");
                 if (issue.LabelsText != null)
                 {
                     text.AppendLine($"      <br/><div class=\"labels\">Labels: {issue.LabelsText}</div>");

--- a/BugReport/Reports/HtmlReport/QueryReport.cs
+++ b/BugReport/Reports/HtmlReport/QueryReport.cs
@@ -3,9 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+using System.Web;
 using BugReport.DataModel;
-using BugReport.Query;
 
 namespace BugReport.Reports
 {
@@ -84,7 +83,7 @@ namespace BugReport.Reports
                 text.AppendLine("  <tr>");
                 text.AppendLine($"    <td>{issue.IssueId}</td>");
                 text.AppendLine("    <td>");
-                text.AppendLine($"      {issue.Title}");
+                text.AppendLine($"      {HttpUtility.HtmlEncode(issue.Title)}");
                 if (issue.LabelsText != null)
                 {
                     text.AppendLine($"      <br/><div class=\"labels\">Labels: {issue.LabelsText}</div>");


### PR DESCRIPTION
Useful for generic class names in titles (e.g. Span<T>)

Fixes #102