### PR TITLE
Fix queries with Assignee

### DIFF
--- a/BugReport/DataModel/DataModelIssue.cs
+++ b/BugReport/DataModel/DataModelIssue.cs
@@ -89,7 +89,7 @@ namespace BugReport.DataModel
             {
                 return (assigneeName == null);
             }
-            return Assignee.Name.Equals(assigneeName, StringComparison.InvariantCultureIgnoreCase);
+            return Assignee.Login.Equals(assigneeName, StringComparison.InvariantCultureIgnoreCase);
         }
 
         public override string ToString()

--- a/BugReport/Query/Expressions_Leaf.cs
+++ b/BugReport/Query/Expressions_Leaf.cs
@@ -342,7 +342,7 @@ namespace BugReport.Query
 
         public override string GetGitHubQueryURL()
         {
-            return "assginee:" + _assigneeName;
+            return "assignee:" + _assigneeName;
         }
 
         internal override bool IsNormalized(NormalizedState minAllowedState)


### PR DESCRIPTION
Fix 2 bugs:
* NullReference (because Name is always null, unlike Login)
* Misspelled 'assignee' in GitHub query links