### PR TITLE
Avoid emails for large changes

### DIFF
--- a/BugReport/Program.cs
+++ b/BugReport/Program.cs
@@ -227,6 +227,11 @@ class Program
                             config, 
                             IssueKindFlags.Issue | IssueKindFlags.PullRequest);
 
+                        if (AlertReport_Diff.DetectLargeChanges(beginIssues, endIssues, config))
+                        {
+                            return ErrorCode.EmailSendFailure;
+                        }
+
                         return GetSendEmailErrorCode(AlertReport_Diff.SendEmails(
                             config,
                             templateFile,


### PR DESCRIPTION
Large changes usually mean GitHub hiccups. Avoid sending such emails.

Large changes: More than 10% issues/PRs in repo (at least 20 issues/PRs).

Fixes #140