### PR TITLE
Fix failure to download CoreFX repo issues

### DIFF
--- a/BugReport/App.config
+++ b/BugReport/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/BugReport/GitHubBugReport.csproj
+++ b/BugReport/GitHubBugReport.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GitHubBugReport</RootNamespace>
     <AssemblyName>GitHubBugReport</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -41,8 +41,8 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Octokit, Version=0.23.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Octokit.0.23.0\lib\net45\Octokit.dll</HintPath>
+    <Reference Include="Octokit, Version=0.32.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Octokit.0.32.0\lib\net45\Octokit.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />

--- a/BugReport/Repository.cs
+++ b/BugReport/Repository.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using BugReport.DataModel;
 using BugReport.Query;
 using BugReport.Util;
+using System;
 
 public class Repository
 {
@@ -270,6 +271,7 @@ public class Repository
     private static void SerializeToFile(string fileName, object objToSerialize)
     {
         JsonSerializer serializer = new JsonSerializer();
+        serializer.Converters.Add(new StringEnumOfItemStateConverter());
         serializer.Formatting = Formatting.Indented;
 
         using (StreamWriter sw = new StreamWriter(fileName))
@@ -277,7 +279,6 @@ public class Repository
         {
             serializer.Serialize(writer, objToSerialize);
         }
-
     }
 
     public override string ToString()
@@ -287,5 +288,23 @@ public class Repository
             return RepoName;
         }
         return $"{RepoName} filtered by '{FilterQuery}'";
+    }
+
+    internal class StringEnumOfItemStateConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return (objectType == typeof(StringEnum<ItemState>));
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return new StringEnum<ItemState>((string)reader.Value);
+        }
     }
 }

--- a/BugReport/packages.config
+++ b/BugReport/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="EPPlus" version="4.5.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
-  <package id="Octokit" version="0.23.0" targetFramework="net471" />
+  <package id="Octokit" version="0.32.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
* Update Octokit to latest version to avoid bug with "Status=Bot" enum value missing
* Add JSon converter for StringEnum<ItemStatus> to avoid its failure to serialize with null value
* Downgrade to 4.6.1 targeting (from 4.7.1) which is sufficient